### PR TITLE
Prevent input editor from getting larger on the REPL

### DIFF
--- a/src/Repl.module.css
+++ b/src/Repl.module.css
@@ -29,6 +29,7 @@
 
 .verticalSplit {
     width: 100%;
+    min-width: 0;
 }
 
 .codeMirrorPanel {


### PR DESCRIPTION
Adds the missing `min-width: 0px` to `.verticalSplit`, this makes it such that flex actually knows the minimum width that the pane can actually take up (the default is `auto`, which makes flex think it cannot be shrunk down)

This fixes the issue with the REPL editor being broken if you try to give it a very long one liner (say, trying to minify an already minified script).